### PR TITLE
renamed pypi test repo alias for consistent use with no .pypirc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
 [distutils]
 index-servers=
     pypi
-    testpypi
+    pypitest
 
 [pypi]
 username = ...
 password = ...
 
-[testpypi]
+[pypitest]
 repository = https://test.pypi.org/legacy/
 username = ...
 password = ...
@@ -31,7 +31,7 @@ password = ...
 
 ```
 $ python setup.py sdist
-$ twine upload dist/* -r testpypi
+$ twine upload dist/* -r pypitest
 ```
 
 Once you are done with this step test to pip install from https://test.pypi.org:


### PR DESCRIPTION
If you don't have a .pypirc file and enter your username / password each time, it seems the built in default alias for the test repo is "pypitest" rather than "testpypi".  So without a .pypirc file, this works just fine:

`twine upload dist/* -r pypitest`

But with the testpypi in the example (using twine version 1.11.0), I got an error trying the twine upload to the test repo:
KeyError: Missing 'testpypi' section from the configuration file

Thought it would be helpful to update the example to work with or without a .pypirc file.  Thanks for your helpful guide!